### PR TITLE
Update ESP8266_WebSocket_Server.ino

### DIFF
--- a/Projects/ESP8266/ESP8266_WebSocket_Server.ino
+++ b/Projects/ESP8266/ESP8266_WebSocket_Server.ino
@@ -88,9 +88,6 @@ const char index_html[] PROGMEM = R"rawliteral(
      font-weight: bold;
    }
   </style>
-<title>ESP Web Server</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="icon" href="data:,">
 </head>
 <body>
   <div class="topnav">


### PR DESCRIPTION
There are two copies of
```html
<title>ESP Web Server</title>
<meta name="viewport" content="width=device-width, initial-scale=1">
<link rel="icon" href="data:,">
```

The first is right above the `<style>` tag. The second is right below.

I deleted the second copy.