### PR TITLE
ESP_DS18B20_Async_Web: Loose "S" in the libraries

### DIFF
--- a/Projects/ESP/ESP_DS18B20_Async_Web_Server.ino
+++ b/Projects/ESP/ESP_DS18B20_Async_Web_Server.ino
@@ -12,7 +12,7 @@
   #include <ESP8266WiFi.h>
   #include <Hash.h>
   #include <ESPAsyncTCP.h>
-  #include <ESPAsyncWebServer.h>S
+  #include <ESPAsyncWebServer.h>
 #endif
 #include <OneWire.h>
 #include <DallasTemperature.h>


### PR DESCRIPTION
Sketch fails to compile with the random S in the library